### PR TITLE
Cull the warnings shown in the Unity editor

### DIFF
--- a/Assets/Plugins/EuclideonUdSDK/Advanced Assets/Scripts/DepthOfFieldEffector.cs
+++ b/Assets/Plugins/EuclideonUdSDK/Advanced Assets/Scripts/DepthOfFieldEffector.cs
@@ -48,7 +48,6 @@ public class DepthOfFieldEffector : MonoBehaviour
         {
             case ChangeMode.Immediate:
                 return; 
-                break;
             case ChangeMode.Lerp:
                 LerpAndChangeValue(ref focalLengthValue,   ref dFocalLengthValue,   ref depthOfFieldEffect.focalLength.value);
                 LerpAndChangeValue(ref apertureValue,      ref dApertureValue,      ref depthOfFieldEffect.aperture.value);

--- a/Assets/Plugins/EuclideonUdSDK/udSDK/UnityObjects/udProjectNodeUnity.cs
+++ b/Assets/Plugins/EuclideonUdSDK/udSDK/UnityObjects/udProjectNodeUnity.cs
@@ -248,7 +248,7 @@ public class udProjectNodeUnity : MonoBehaviour
         }
 
         lr.SetPositions(verts);
-        lr.SetWidth(project.appearance.lineSize, project.appearance.lineSize);
+        lr.startWidth = lr.endWidth = project.appearance.lineSize;
         break;
 
       case(udProjectGeometryType.udPGT_MultiLineString): //!<Array of udPGT_LineString; pCoordinates is NULL and children will be present.


### PR DESCRIPTION
Removing warnings being thrown by now deprecated functions